### PR TITLE
Ensure Jenkin jobs copied to proper directory.

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -84,7 +84,7 @@
     - name: Copy Jenkins jobs into place.
       copy:
         src: templates/jobs
-        dest: /var/lib/jenkins/jobs
+        dest: /var/lib/jenkins
       notify: restart jenkins
       become: yes
       become_user: jenkins


### PR DESCRIPTION
After deploying to a server the jobs were in a subdirectory `jobs` of `/var/lib/jenkins/jobs`.

Issue #5 