### PR TITLE
Fix root SSH error

### DIFF
--- a/vars/config.yml
+++ b/vars/config.yml
@@ -15,7 +15,7 @@ firewall_allowed_tcp_ports:
 firewall_disable_ufw: True
 
 # Security configuration.
-security_ssh_permit_root_login: True
+security_ssh_permit_root_login: 'yes'
 
 # Jenkins configuration.
 jenkins_admin_username: admin


### PR DESCRIPTION
I've set up a new Ubuntu 16.04 server to test this out (I've also tried with Debian), but the playbook fails and I'm locked out of the server.

```
fatal: [139.162.215.53]: FAILED! => {"changed": false, "msg": "Unable to restart service ssh: Job for ssh.service failed because the control process exited with error code. See \"systemctl status ssh.service\" and \"journalctl -xe\" for details.\n"}
```

If I still have a prior SSH connection then I also get an error when trying to restart the SSH service.

```
root@localhost:~# service ssh restart
Job for ssh.service failed because the control process exited with error code.
See "systemctl status ssh.service" and "journalctl -xe" for details.
```

This seems to be because in `/etc/ssh/sshd_config`, `PermitRootLogin yes` has changed to `PermitRootLogin True` which is not valid.

This PR fixes the default value for `security_ssh_permit_root_login` in this project so it matches the example in https://github.com/geerlingguy/ansible-role-firewall/blob/master/README.md and uses a string so that it adds a valid value into the SSH config.